### PR TITLE
Fix bozo_exception attribute error

### DIFF
--- a/flirror/crawler/crawlers.py
+++ b/flirror/crawler/crawlers.py
@@ -265,7 +265,7 @@ class NewsfeedCrawler(Crawler):
         # The feedparser will set the bozo flag/exception whenever something went wrong
         # (e.g. the XML is not well formatted or couldn't be retrieved at all):
         # https://pythonhosted.org/feedparser/bozo.html
-        if feed.bozo_exception:
+        if "bozo_exception" in feed and feed.bozo_exception:
             raise CrawlerDataError(
                 f"Could not retrieve any news for '{self.name}' due to "
                 f"'{feed.bozo_exception}'"


### PR DESCRIPTION
When making the flirror crawlers more robust, I was too optimistic about
the exception field being always present in the newsfeed library.