### PR TITLE
Update Python version to 3.7 in tox and Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 services:
   - docker
 python:
-  - "3.6"
+  - "3.7"
 install: pip install tox-travis
 jobs:
   include:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, dev
+envlist = py37, dev
 
 [testenv]
 description = Running static code checks and unit tests


### PR DESCRIPTION
So far, this was set to 3.6 because 3.7 was not available in Travis CI.