### PR TITLE
Provide a docker-compose example file for flirror deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
   The tag `latest` always contains the latest master state. For each release a
   dedicated tag with the release version will be available (e.g. `1.0.0`).
 
+  Docker builds for Raspberry Pi are not automated yet as they must be built on
+  armv7 architecture which is not supported by Docker Hub. Thus, they are built
+  manually on a Raspberry Pi for now. There will be docker images available for
+  each release, although I'm not sure if I will follow up on the master
+  until these builds are automated. The resulting docker images will be tagged
+  as `latest-armv7`, or for a release e.g. `1.0.0-armv7`.
+
 ### Fixes
 - Added missing gunicorn depedency.
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,24 @@ simple key value pairs and SQLite comes
 
 ## Usage
 
+### Installation
+
+Flirror can simply be installed via pip:
+```shell
+$ pip install flirror
+```
+
+or via docker:
+```shell
+$ docker pull felixedel/flirror
+```
+
+Deploying flirror via docker is simplest using docker-compose. An example
+docker-compose stack can be found in the `deploy/docker-compose.example.yaml`
+file.
+
+### Configuration
+
 Both applications - **flirror-web** and **flirror-crawler** - read their
 configuration from the file path given via the `FLIRROR_SETTINGS` environment
 variable, e.g.

--- a/README.md
+++ b/README.md
@@ -298,16 +298,18 @@ $ pipx install docker-compose
 
 ### Start flirror
 
-Both components, `flirror-web` and `flirror-crawler` can be started via the
-`docker-compose.yaml` file within this repository. Thus, you can simply start
-both services by running
+Both componenents can be started using the docker-compose file provided in
+`deploy/docker-compose.example.yaml`. You just need to change the `latest`
+tag of the image used for both services to `latest:armv7` since a Raspberry Pi
+is using arm architecture and that needs a dedicated docker image.
+
+Afterwards, simply run
 
 ```shell
-$ docker-compose up web crawler
+$ docker-compose up
 ```
 
-within the root of this repository. This will start the web UI and the crawler
-application in periodic mode.
+to start the web server and the crawler in periodic mode.
 
 With both services running we still need to open some browser to see the actual
 flirror UI. This can be done by executing the `helpers/start_gui.sh` helper

--- a/deploy/docker-compose.example.yaml
+++ b/deploy/docker-compose.example.yaml
@@ -1,0 +1,29 @@
+version: "3"
+services:
+  web:
+    image: felixedel/flirror:latest
+    ports:
+      - "8000:8000"
+    environment:
+      - FLIRROR_SETTINGS=/opt/settings.cfg
+      - FLIRROR_VERBOSITY=debug
+    volumes:
+      # Mount settings file
+      - ./settings.cfg:/opt/settings.cfg
+      # Use volume for database
+      - db-data:/opt/flirror-data
+  crawler:
+    image: felixedel/flirror:latest
+    environment:
+      - FLIRROR_SETTINGS=/opt/settings.cfg
+      - FLIRROR_VERBOSITY=debug
+      - GOOGLE_OAUTH_CLIENT_SECRET=/opt/goauth_client_secret.json
+    volumes:
+      # Mount settings and google oauth secret file
+      - ./settings.cfg:/opt/settings.cfg
+      - ./goauth_client_secret.json:/opt/goauth_client_secret.json
+      # Use volume for database
+      - db-data:/opt/flirror-data
+    command: flirror-crawler crawl --periodic
+volumes:
+  db-data:

--- a/deploy/docker-compose.example.yaml
+++ b/deploy/docker-compose.example.yaml
@@ -1,6 +1,9 @@
 version: "3"
 services:
   web:
+    # Use the following image instead if you want to deploy flirror
+    # on a Raspberry Pi
+    # image: felixedel/flirror:latest-armv7
     image: felixedel/flirror:latest
     ports:
       - "8000:8000"
@@ -13,6 +16,9 @@ services:
       # Use volume for database
       - db-data:/opt/flirror-data
   crawler:
+    # Use the following image instead if you want to deploy flirror
+    # on a Raspberry Pi
+    # image: felixedel/flirror:latest-armv7
     image: felixedel/flirror:latest
     environment:
       - FLIRROR_SETTINGS=/opt/settings.cfg

--- a/settings.example.cfg
+++ b/settings.example.cfg
@@ -2,7 +2,7 @@
 # http://flask.pocoo.org/docs/1.0/quickstart/#sessions
 SECRET_KEY = '_5#y2L"F4Q8z\n\xec]/'
 
-DATABASE_FILE = "database.sqlite"
+DATABASE_FILE = "/opt/flirror-data/database.sqlite"
 
 MODULES = [
     {


### PR DESCRIPTION
The docker-compose.example.yaml file uses the image uploaded to docker
hub instead of the local flirror-Dockerfile.