### PR TITLE
Rename config key modules.type to modules.module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Deprecated
+- Change the config key `modules.type` to `modules.module`. This key is used to
+  specify which module should be used for this element in the configuration
+  file. Renaming this key makes it more clear that one should specify the
+  module's name there and not some mysterious "type". The old version is still
+  supported, but will be removed in future versions.
+
 ## [v1.0.1] - 2020-02-28
 
 ### Notes

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Each entry in the `MODULES` list accepts the following parameters:
 | Parameter | Description
 |-----------|------------
 | `id` | **Required** The ID to identify this module inside the application.
-| `type` | **Required** The name of the module to use for this tile. A list of available modules can be found [here](#available-modules)
+| `module` | **Required** The name of the module to use for this tile. A list of available modules can be found [here](#available-modules)
 | `config` | **Required** The configuration for the specific module. Some modules come up with a default configuration, but usually this is needed to for each module. For more details on how to configure the specific module, take a look at the module's configuration part in the [modules](#available-modules) section.
 | `crawler` | Crawler specific settings. This can be used to speficy e.g.the crawling interval for a specific module. For more details see the crawler config section.
 | `display` | Configure the `position` and reloading `time` of a module

--- a/flirror/__init__.py
+++ b/flirror/__init__.py
@@ -113,9 +113,8 @@ class Flirror(Flask):
         # Build template context and return template via JSON
         context = {
             "module": {
-                # TODO (felix): Is the type still needed here? We shouldn't do
-                # any further lookup on that.
-                "type": module_config["type"],
+                # TODO (felix): Remove this fallback in a later future version
+                "name": module_config.get("module") or module_config.get("type"),
                 "id": module_id,
                 "config": module_config["config"],
                 "display": module_config["display"],

--- a/flirror/crawler/main.py
+++ b/flirror/crawler/main.py
@@ -90,24 +90,25 @@ def crawl(ctx, module, periodic):
     # Look up crawlers from config file
     for crawler_config in crawler_configs:
         crawler_id = crawler_config.get("id")
-        crawler_type = crawler_config.get("type")
+        # TODO (felix): Remove this fallback in a later future version
+        crawler_name = crawler_config.get("module") or crawler_config.get("type")
         # TODO Error handling for wrong/missing keys
         LOGGER.info(
-            "Initializing crawler of type '%s' with id '%s'", crawler_type, crawler_id
+            "Initializing crawler of type '%s' with id '%s'", crawler_name, crawler_id
         )
 
         # Get crawler callable from module
-        crawler_module = app.modules.get(crawler_type)
+        crawler_module = app.modules.get(crawler_name)
         if not crawler_module:
             LOGGER.warning(
                 "Could not find any registered module '%s'. Skipping this crawler.",
-                crawler_type,
+                crawler_name,
             )
             continue
         crawler_callable = crawler_module._crawler
         if not crawler_callable:
             LOGGER.warning(
-                "Module '%s' does not provide any crawler. Skipping.", crawler_type
+                "Module '%s' does not provide any crawler. Skipping.", crawler_name
             )
             continue
 

--- a/flirror/modules/clock/__init__.py
+++ b/flirror/modules/clock/__init__.py
@@ -28,7 +28,7 @@ def get():
 
     context = {
         "module": {
-            "type": module_config["type"],
+            "module": "clock",
             "id": module_id,
             "config": module_config["config"],
         }

--- a/flirror/templates/ajax.html
+++ b/flirror/templates/ajax.html
@@ -14,7 +14,7 @@
             type: 'GET',
             {# If the module is configured properly (using the view() decorator), it
                should be reachable via /<module_name>/ #}
-            url: '{{ module.type }}',
+            url: '{{ module.name }}',
             data: {{ {"module_id": module.id, "output": "template"} | safe }},
             success: function (response) {
                 // TODO Remove debug output

--- a/flirror/templates/index.html
+++ b/flirror/templates/index.html
@@ -3,7 +3,7 @@
 {% block body %}
 <div class="pt-4">
     <div class="row">
-        {% for position, modules in modules.items() %}
+        {% for position, modules in tiles.items() %}
             {# Check if we have more than one module for this position,
             and if so use a carousel to show all in one place #}
             {% if modules | length > 1 %}

--- a/flirror/views.py
+++ b/flirror/views.py
@@ -45,7 +45,7 @@ class IndexView(FlirrorMethodView):
         # The dictionary holding all necessary context data for the index
         # template. Here we have also place for overall meta data (like flirror
         # version or so).
-        ctx_data = {"modules": defaultdict(list)}
+        ctx_data = {"tiles": defaultdict(list)}
 
         config_modules = current_app.config.get("MODULES", [])
 
@@ -58,16 +58,17 @@ class IndexView(FlirrorMethodView):
         for position, module_configs in sort_pos_modules.items():
             for module_config in module_configs:
                 module_id = module_config.get("id")
-                module_type = module_config.get("type")
+                # TODO (felix): Remove this fallback in a later future version
+                module_name = module_config.get("module") or module_config.get("type")
                 # TODO Error handling for wrong/missing keys
 
                 # NOTE (felix): The index view will only ensure that the
                 # modules are positioned properly. The content of each tile
                 # will be loaded asynchronously via ajax.
-                ctx_data["modules"][position].append(
+                ctx_data["tiles"][position].append(
                     {
                         "id": module_id,
-                        "type": module_type,
+                        "name": module_name,
                         "config": module_config["config"],
                         "display": module_config["display"],
                     }

--- a/settings.example.cfg
+++ b/settings.example.cfg
@@ -7,7 +7,7 @@ DATABASE_FILE = "/opt/flirror-data/database.sqlite"
 MODULES = [
     {
         "id": "weather-hometown",
-        "type": "weather",
+        "module": "weather",
         "config": {
             # Where to retrieve the weather data for
             "city": "My hometown",
@@ -28,7 +28,7 @@ MODULES = [
     },
     {
         "id": "calendar-personal",
-        "type": "calendar",
+        "module": "calendar",
         "config": {
             "calendars": ["contacts", "<my-account>@googlemail.com"],
             "max_items": 5,
@@ -42,7 +42,7 @@ MODULES = [
     },
     {
         "id": "stocks-series",
-        "type": "stocks",
+        "module": "stocks",
         "config": {
             "mode": "series",
             "api_key": "askjfasg89safa",
@@ -56,7 +56,7 @@ MODULES = [
     },
     {
         "id": "stocks-table",
-        "type": "stocks",
+        "module": "stocks",
         "config": {
             "mode": "table",
             "api_key": "askjfasg89safa",
@@ -71,7 +71,7 @@ MODULES = [
     },
     {
         "id": "news-tagesschau",
-        "type": "newsfeed",
+        "module": "newsfeed",
         "config": {
             "name": "Tagesschau",
             "url": "http://www.tagesschau.de/xml/atom/",


### PR DESCRIPTION
This makes it more clear that one should specify the module's name here
and not some mysterious type.

To avoid having the name modules on different hierarchy levels in the
data structure, I renamed the "modules" list used in the template
context to "tiles" (which is what they are in the end - from a visual
point of view).