### PR TITLE
Rename crawler_id to module_id

### DIFF
--- a/flirror/modules/calendar/__init__.py
+++ b/flirror/modules/calendar/__init__.py
@@ -33,11 +33,11 @@ def get():
 
 
 @calendar_module.crawler()
-def crawl(crawler_id, app, calendars, max_items=DEFAULT_MAX_ITEMS):
+def crawl(module_id, app, calendars, max_items=DEFAULT_MAX_ITEMS):
 
     # TODO (felix): Get rid of this, it's only needed to store the oauth token
     # in GoogleOAuth for the current module.
-    object_key = f"{FLIRROR_OBJECT_KEY}-{crawler_id}"
+    object_key = f"{FLIRROR_OBJECT_KEY}-{module_id}"
 
     try:
         credentials = GoogleOAuth(
@@ -110,7 +110,7 @@ def crawl(crawler_id, app, calendars, max_items=DEFAULT_MAX_ITEMS):
     all_events = sorted(all_events, key=lambda k: k["start"])
 
     event_data = {"_timestamp": now, "events": all_events[:max_items]}
-    app.store_module_data(crawler_id, FLIRROR_OBJECT_KEY, event_data)
+    app.store_module_data(module_id, FLIRROR_OBJECT_KEY, event_data)
 
 
 def _parse_event_data(event):

--- a/flirror/modules/newsfeed/__init__.py
+++ b/flirror/modules/newsfeed/__init__.py
@@ -24,7 +24,7 @@ def get():
 
 
 @newsfeed_module.crawler()
-def crawl(crawler_id, app, url, name, max_items=DEFAULT_MAX_ITEMS):
+def crawl(module_id, app, url, name, max_items=DEFAULT_MAX_ITEMS):
     LOGGER.info("Requesting news feed '%s' from '%s'", name, url)
 
     news_data = {"_timestamp": time.time(), "news": []}
@@ -56,4 +56,4 @@ def crawl(crawler_id, app, url, name, max_items=DEFAULT_MAX_ITEMS):
             }
         )
 
-    app.store_module_data(crawler_id, FLIRROR_OBJECT_KEY, news_data)
+    app.store_module_data(module_id, FLIRROR_OBJECT_KEY, news_data)

--- a/flirror/modules/stocks/__init__.py
+++ b/flirror/modules/stocks/__init__.py
@@ -28,7 +28,7 @@ def list_filter(list_of_dicts_to_filter, key):
 
 
 @stocks_module.crawler()
-def crawl(crawler_id, app, api_key, symbols, mode="table"):
+def crawl(module_id, app, api_key, symbols, mode="table"):
     ts = TimeSeries(key="YOUR_API_KEY")
     stocks_data = {"_timestamp": time.time(), "stocks": []}
 
@@ -89,4 +89,4 @@ def crawl(crawler_id, app, api_key, symbols, mode="table"):
             # '2. Symbol': 'GOOGL', '3. Last Refreshed': '2019-10-04 16:00:00',
             # '4. Interval': '15min', '5. Output Size': 'Compact', '6. Time Zone': 'US/Eastern'}
 
-    app.store_module_data(crawler_id, FLIRROR_OBJECT_KEY, stocks_data)
+    app.store_module_data(module_id, FLIRROR_OBJECT_KEY, stocks_data)

--- a/flirror/modules/weather/__init__.py
+++ b/flirror/modules/weather/__init__.py
@@ -57,13 +57,13 @@ def get():
 
 
 @weather_module.crawler()
-def crawl(crawler_id, app, api_key, language, city, temp_unit):
-    WeatherCrawler(crawler_id, app, api_key, language, city, temp_unit).crawl()
+def crawl(module_id, app, api_key, language, city, temp_unit):
+    WeatherCrawler(module_id, app, api_key, language, city, temp_unit).crawl()
 
 
 class WeatherCrawler:
-    def __init__(self, crawler_id, app, api_key, language, city, temp_unit):
-        self.crawler_id = crawler_id
+    def __init__(self, module_id, app, api_key, language, city, temp_unit):
+        self.module_id = module_id
         self.app = app
         self.api_key = api_key
         self.language = language
@@ -100,7 +100,7 @@ class WeatherCrawler:
         # Store the crawl timestamp
         weather_data["_timestamp"] = now
 
-        self.app.store_module_data(self.crawler_id, FLIRROR_OBJECT_KEY, weather_data)
+        self.app.store_module_data(self.module_id, FLIRROR_OBJECT_KEY, weather_data)
 
     @property
     def owm(self):


### PR DESCRIPTION
This unifies the parameters between view and crawler, so we always have
module_* variables in both places. This should also clearify the module
API for custom plugins a little bit.