### PR TITLE
Keep libjpeg as runtime dependency in flirror-Dockerfile

### DIFF
--- a/dockerfiles/flirror-Dockerfile
+++ b/dockerfiles/flirror-Dockerfile
@@ -65,6 +65,9 @@ FROM python:3.8.1-alpine3.11
 
 WORKDIR /opt/
 
+# Install runtime dependencies for CPython library pillow
+RUN apk add --no-cache libjpeg
+
 # Copy the application files together with the application's venv (with all
 # python dependencies installed) from the builder stage and ensure that the
 # Flirror executable can be found in the application's venv.


### PR DESCRIPTION
Since we are using a multi-stage Docker image now, this dependency must
be installed as runtime dependency in the final stage. Otherwise we are
not able to load the needed python classes from Pillow (in our case
qrcode which uses Pillow).