### PR TITLE
Fix travis CI warnings and switch to bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
-sudo: false
 language: python
+os: linux
+dist: bionic
 services:
   - docker
 python:


### PR DESCRIPTION
I just noticed these warnings when looking into the build results on
travis-ci.com. I don't do that often since the GitHub checks results are
sufficient for most use cases.

Looks like some keys got deprecated in the meantime or where missing the
whole time.
- root: deprecated key sudo (The key `sudo` has no effect anymore.)
- root: missing dist, using the default xenial
- root: missing os, using the default linux